### PR TITLE
fix: Fix HTML class Attribute to Comply with Standards

### DIFF
--- a/src/stories/Welcome.mdx
+++ b/src/stories/Welcome.mdx
@@ -67,7 +67,7 @@ By default, Ink Kit provides a couple of themes already in the stylesheet:
 To specify which theme to use, add the `ink:THEME_ID` to your document root:
 
 ```tsx
-<html class="ink:dark-theme">
+<html class="ink-dark-theme">
   ...
 ```
 


### PR DESCRIPTION
As far as I remember, the `class` attribute does not support colons (`:`) in class names, as it violates the HTML standard.