### PR TITLE
fix incorrect syntax

### DIFF
--- a/src/components/Card/Content/Image.tsx
+++ b/src/components/Card/Content/Image.tsx
@@ -19,7 +19,7 @@ export const Image: React.FC<ImageProps> = ({
   return (
     <div
       className={classNames(
-        "ink:rounded-(--ink-card-rounded) ink:overflow-hidden ink:box-border ink:relative",
+        "ink:rounded-[--ink-card-rounded] ink:overflow-hidden ink:box-border ink:relative",
         className
       )}
     >

--- a/src/components/Card/Content/LargeLink.tsx
+++ b/src/components/Card/Content/LargeLink.tsx
@@ -27,7 +27,7 @@ export const LargeLink = ({
       href={href}
       target={target}
       className={classNames(
-        "ink:p-3 ink:bg-button-secondary ink:text-(--ink-card-default-color) ink:text-h5 ink:rounded-lg ink:box-border",
+        "ink:p-3 ink:bg-button-secondary ink:text-[--ink-card-default-color] ink:text-h5 ink:rounded-lg ink:box-border",
         "ink:flex ink:justify-between ink:items-center ink:gap-0.5",
         "ink:min-w-[200px]",
         href && "ink:cursor-pointer ink:hover:bg-button-secondary-hover",

--- a/src/components/Card/Content/TitleAndDescription.tsx
+++ b/src/components/Card/Content/TitleAndDescription.tsx
@@ -15,7 +15,7 @@ export const TitleAndDescription = ({
     <div className="ink:flex ink:flex-col ink:gap-2">
       <h3
         className={classNames(
-          "ink:text-body-1-bold ink:text-(--ink-card-default-color) ink:box-border ink:m-0 ink:-my-px",
+          "ink:text-body-1-bold ink:text-[--ink-card-default-color] ink:box-border ink:m-0 ink:-my-px",
           variantClassNames(size, {
             default: "ink:text-h3",
             small: "ink:text-body-1-regular",
@@ -28,7 +28,7 @@ export const TitleAndDescription = ({
       {description && (
         <div
           className={classNames(
-            "ink:text-body-3-regular ink:text-(--ink-card-muted-color) ink:box-border ink:m-0",
+            "ink:text-body-3-regular ink:text-[--ink-card-muted-color] ink:box-border ink:m-0",
             variantClassNames(size, {
               default: "ink:text-body-1-regular",
               small: "ink:text-body-3-regular",

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -120,7 +120,7 @@ export const NestingWithIndeterminateState: Story = {
   },
 };
 
-/** If you want to use the Checkbox without it's own managed state, set checked={undefined} and onChange={undefined}, and add `data-checked={value}` to the parent item. */
+/** If you want to use the Checkbox without its own managed state, set checked={undefined} and onChange={undefined}, and add `data-checked={value}` to the parent item. */
 export const ManagedByAParentItem: Story = {
   argTypes: {
     onChange: {


### PR DESCRIPTION
This PR corrects syntax and typographical issues in the codebase:  

**Fixed CSS variable syntax:**  
Updated incorrect syntax `ink:text-(--ink-card-default-color)` to `ink:text-[--ink-card-default-color]` across multiple components (`Image.tsx`, `LargeLink.tsx`, `TitleAndDescription.tsx`) that ensures proper Tailwind handling of CSS variables within `classNames`.  

**Fixed a grammar mistake in Checkbox documentation:**  
Changed **"it's own"** to **"its own"** in `Checkbox.stories.tsx` to reflect proper English grammar.