### PR TITLE
fix: card columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkonchain/ink-kit",
-  "version": "0.9.1-beta.16",
+  "version": "0.9.1-beta.18",
   "description": "",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/src/components/Card/Content/CardInfos.tsx
+++ b/src/components/Card/Content/CardInfos.tsx
@@ -10,7 +10,7 @@ export const CardInfos = ({ children, className }: CardInfosProps) => {
   return (
     <div
       className={classNames(
-        "ink:grid ink:grid-cols-[repeat(auto-fit,minmax(max(200px,calc(100%/3)),1fr))] ink:xl:grid-cols-2 ink:gap-1 ink:box-border",
+        "ink:grid ink:grid-cols-[repeat(auto-fit,minmax(max(200px,calc(100%/3)),1fr))] ink:gap-1 ink:box-border",
         className
       )}
     >

--- a/src/components/Card/Content/LargeLinks.tsx
+++ b/src/components/Card/Content/LargeLinks.tsx
@@ -10,7 +10,7 @@ export const LargeLinks = ({ children, className }: LargeLinksProps) => {
   return (
     <div
       className={classNames(
-        "ink:grid ink:grid-cols-[repeat(auto-fit,minmax(max(200px,calc(100%/3)),1fr))] ink:xl:grid-cols-2 ink:gap-1 ink:box-border",
+        "ink:grid ink:grid-cols-[repeat(auto-fit,minmax(max(200px,calc(100%/3)),1fr))] ink:gap-1 ink:box-border",
         className
       )}
     >


### PR DESCRIPTION
Make it so the large card properly resizes/wraps over the xl breakpoint.

Without that, the divs could bleed (because of the minimum width)