### PR TITLE
chore: fix import.meta.dirname usage in the project

### DIFF
--- a/scripts/import-svgs.mjs
+++ b/scripts/import-svgs.mjs
@@ -97,7 +97,7 @@ async function createIndexFile(folder) {
   );
 }
 
-const currentDir = import.meta.dirname;
+const currentDir = new URL('.', import.meta.url).pathname;
 const dirToProcess = path.join(currentDir, "../src/icons");
 await processSvgsInFolder(dirToProcess);
 await createIndexFile(dirToProcess);


### PR DESCRIPTION
i've fixed an issue where `import.meta.dirname` was used incorrectly.
the correct approach is to use `import.meta.url`, and i’ve updated the code accordingly.

p.s. this resolves the problem and ensures compatibility with the latest standards.